### PR TITLE
Removed exposed infant as baseline hiv status for patient contact and created a chore for historical data

### DIFF
--- a/api/src/main/java/org/openmrs/module/hivtestingservices/advice/model/HTSContactListingFormProcessor.java
+++ b/api/src/main/java/org/openmrs/module/hivtestingservices/advice/model/HTSContactListingFormProcessor.java
@@ -237,7 +237,6 @@ public class HTSContactListingFormProcessor {
         Map<Concept, String> hivStatusList = new HashMap<Concept, String>();
         hivStatusList.put(conceptService.getConcept(703), "Positive");
         hivStatusList.put(conceptService.getConcept(664), "Negative");
-        hivStatusList.put(conceptService.getConcept(1405), "Exposed");
         hivStatusList.put(conceptService.getConcept(1067), "Unknown");
         return hivStatusList.get(key);
     }

--- a/api/src/main/java/org/openmrs/module/hivtestingservices/chore/MigrateFamilyHistoryFormContactListingChore.java
+++ b/api/src/main/java/org/openmrs/module/hivtestingservices/chore/MigrateFamilyHistoryFormContactListingChore.java
@@ -198,7 +198,6 @@ public class MigrateFamilyHistoryFormContactListingChore {
         Map<Concept, String> hivStatusList = new HashMap<Concept, String>();
         hivStatusList.put(conceptService.getConcept(703), "Positive");
         hivStatusList.put(conceptService.getConcept(664), "Negative");
-        hivStatusList.put(conceptService.getConcept(1405), "Exposed");
         hivStatusList.put(conceptService.getConcept(1067), "Unknown");
         return hivStatusList.get(key);
     }

--- a/api/src/main/java/org/openmrs/module/hivtestingservices/chore/UpdateExposedInfantBaselineHivStatusToNegative.java
+++ b/api/src/main/java/org/openmrs/module/hivtestingservices/chore/UpdateExposedInfantBaselineHivStatusToNegative.java
@@ -1,0 +1,35 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.hivtestingservices.chore;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyacore.chore.AbstractChore;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+
+/**
+ * Update exposed infant baseline hiv status to Negative
+ *
+ */
+@Component("kenyaemr.chore.updateExposedInfantBaselineHivStatusToNegative")
+public class UpdateExposedInfantBaselineHivStatusToNegative extends AbstractChore {
+    /**
+     * @see AbstractChore#perform(PrintWriter)
+     */
+
+    @Override
+    public void perform(PrintWriter out) {
+        String updateSql = "update  kenyaemr_hiv_testing_patient_contact set baseline_hiv_status = 'Negative' where baseline_hiv_status='Exposed Infant';";
+        Context.getAdministrationService().executeSQL(updateSql, false);
+        out.println("Updated exposed infant baseline hiv status to Negative");
+
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/hivtestingservices/fragment/controller/ContactTreeViewFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/hivtestingservices/fragment/controller/ContactTreeViewFragmentController.java
@@ -436,7 +436,6 @@ public class ContactTreeViewFragmentController {
         Map<Concept, String> hivStatusList = new HashMap<Concept, String>();
         hivStatusList.put(conceptService.getConcept(703), "Positive");
         hivStatusList.put(conceptService.getConcept(664), "Negative");
-        hivStatusList.put(conceptService.getConcept(1405), "Exposed");
         hivStatusList.put(conceptService.getConcept(1067), "Unknown");
         return hivStatusList.get(key);
     }

--- a/omod/src/main/java/org/openmrs/module/hivtestingservices/fragment/controller/PatientContactFormFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/hivtestingservices/fragment/controller/PatientContactFormFragmentController.java
@@ -73,7 +73,7 @@ public class PatientContactFormFragmentController {
     }
 
     private List<String> hivStatusOptions() {
-        return Arrays.asList("Unknown", "Positive", "Negative", "Exposed Infant");
+        return Arrays.asList("Unknown", "Positive", "Negative");
     }
 
     private List<String> ipvOutcomeOptions() {

--- a/omod/src/main/java/org/openmrs/module/hivtestingservices/page/controller/FamilyAndPartnerTestingPageController.java
+++ b/omod/src/main/java/org/openmrs/module/hivtestingservices/page/controller/FamilyAndPartnerTestingPageController.java
@@ -522,7 +522,6 @@ public class FamilyAndPartnerTestingPageController {
         Map<Concept, String> hivStatusList = new HashMap<Concept, String>();
         hivStatusList.put(conceptService.getConcept(703), "Positive");
         hivStatusList.put(conceptService.getConcept(664), "Negative");
-        hivStatusList.put(conceptService.getConcept(1405), "Exposed");
         hivStatusList.put(conceptService.getConcept(1067), "Unknown");
         hivStatusList.put(conceptService.getConcept(1138), "Inconclusive");
         return hivStatusList.get(key);


### PR DESCRIPTION
Removed exposed infant as baseline hiv status for patient contact and created a chore for historical dat
![baseline](https://user-images.githubusercontent.com/1901372/162163352-49cc7eda-560c-4a16-a153-cc9af039f704.PNG)
a